### PR TITLE
Update arrgb.py to work with Python2 and Python3.

### DIFF
--- a/examples/arrgb.py
+++ b/examples/arrgb.py
@@ -8,7 +8,7 @@ r, g, b = 255, 0, 0
 
 delay = 0.1
 
-half_way = ledshim.NUM_PIXELS / 2
+half_way = ledshim.NUM_PIXELS // 2
 
 while True:
     # Turn pixels on


### PR DESCRIPTION
This code was failing on Python3, with this change it works on both Python2 and Python3.

```
Traceback (most recent call last):
  File "arrgb.py", line 15, in <module>
    for x in range(half_way):
TypeError: 'float' object cannot be interpreted as an integer
```